### PR TITLE
Switch to and configure MySQL 8 image (ASC-6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,7 @@ docker-compose restart app
 | [http://localhost:8091/aspace-indexer/](http://localhost:8091/aspace-indexer/)                           | the indexer                                              |
 | [http://localhost:8888/archivesspace/api/](http://localhost:8888/archivesspace/api/)                     | the API documentation                                    |
 | [http://localhost:8983/solr/#/](http://localhost:8983/solr/#/)                                           | the external Solr admin console                          |
-| jdbc:mysql://localhost:3306/archivesspace?user=as&password=as123&useUnicode=true&characterEncoding=UTF-8 | the database                                             |
-```text
-DBMS: MySQL (ver. 5.5.5-10.11.2-MariaDB)
-Case sensitivity: plain=exact, delimited=exact
-Driver: MySQL Connector/J (ver. mysql-connector-java-8.0.25 (Revision: 08be9e9b4cba6aa115f9b27b215887af40b159e0), JDBC4.2)
-Effective version: MariaDB (ver. 10.11.2)
 
-Ping: 24 ms
-SSL: no
-```
 To start using the Staff interface application, log in using the adminstrator account:
 * Username: admin
 * Password: admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
     command: [
       '--character-set-server=utf8mb4',
       '--collation-server=utf8mb4_unicode_ci',
-      '--socket=/tmp/mysql.sock',
       '--log_bin_trust_function_creators=1'
     ]
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,13 +27,19 @@ services:
 #    command: sleep infinity
 
   db:
-    image: bitnami/mariadb
+    image: mysql:8
     environment:
-      - ALLOW_EMPTY_PASSWORD=yes
-      - MARIADB_DATABASE=archivesspace
-      - MARIADB_USER=as
-      - MARIADB_PASSWORD=as123
-      - TZ=America/Detroit
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+      - MYSQL_ROOT_PASSWORD=asroot123
+      - MYSQL_DATABASE=archivesspace
+      - MYSQL_USER=as
+      - MYSQL_PASSWORD=as123
+    command: [
+      '--character-set-server=utf8mb4',
+      '--collation-server=utf8mb4_unicode_ci',
+      '--socket=/tmp/mysql.sock',
+      '--log_bin_trust_function_creators=1'
+    ]
     volumes:
       - db-data:/var/lib/mysql
     ports:


### PR DESCRIPTION
This PR aims to resolve [ASC-6](https://mlit.atlassian.net/jira/software/projects/ASC/boards/88?selectedIssue=ASC-6).

Resources
- [MySQL on Docker Hub](https://hub.docker.com/_/mysql)
- [`docker-compose-dev.yml` from `archivesspace`](https://github.com/archivesspace/archivesspace/blob/3847263907ac5b6444f6855c54bd08347f660bc1/docker-compose-dev.yml#L5-L23)