### PR TITLE
Add route YAML to `k8s` (ASC-18)

### DIFF
--- a/k8s/app/route-staff.yml
+++ b/k8s/app/route-staff.yml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    service: aspace
+  name: aspace
+spec:
+  # host: something.something.umich.edu
+  port:
+    targetPort: 8080
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  to:
+    kind: Service
+    name: aspace


### PR DESCRIPTION
This PR aims to resolve [ASC-18](https://mlit.atlassian.net/jira/software/projects/ASC/boards/88?selectedIssue=ASC-18). 

This is essentially just a template, but will work as is to create a basic route in OpenShift with an auto-generated host. Modifications will be needed for most use cases.
