### PR TITLE
Double memory for Solr

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as build_release
+FROM ubuntu:22.04 AS build_release
 
 ARG ASPACE_VERSION=latest
 ENV ASPACE_VERSION=$ASPACE_VERSION
@@ -38,8 +38,8 @@ RUN ls -l /archivesspace/solr
 
 FROM solr:8.10
 
-ENV SOLR_JAVA_MEM="-Xms1024m -Xmx1024m"
-ENV SOLR_HEAP="1024m"
+ENV SOLR_JAVA_MEM="-Xms2048m -Xmx2048m"
+ENV SOLR_HEAP="2048m"
 
 COPY --from=build_release /archivesspace/solr /opt/solr/server/solr/configsets/archivesspace/conf
 


### PR DESCRIPTION
This PR adjusts the memory settings for Solr, doubling the startup and maximum memory.

We made this change for the Bentley's instance and timeout reports have dropped significantly. Thus it seems like it's time to put it in the image and let the other instances take advantage of it.

Resource(s)
- https://solr.apache.org/guide/8_10/taking-solr-to-production.html